### PR TITLE
'View All Roles' can now display all content needed

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,9 +3,9 @@ CREATE DATABASE employeeTracker_db;
 
 USE employeeTracker_db;
 
-CREATE TABLE department (
+CREATE TABLE departments (
   id INT PRIMARY KEY AUTO_INCREMENT,
-  name VARCHAR(30)
+  department VARCHAR(30)
 );
 
 CREATE TABLE role (
@@ -13,7 +13,7 @@ CREATE TABLE role (
   title VARCHAR(30),
   salary DECIMAL,
   department_id INT,
-  FOREIGN KEY (department_id) REFERENCES department(id)
+  FOREIGN KEY (department_id) REFERENCES departments(id)
 );
 
 CREATE TABLE employee (

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,4 +1,4 @@
-INSERT INTO department (name)
+INSERT INTO departments (department)
 VALUES ('Administrative'),
        ('Game Design'),
        ('Programming'),

--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ class CLI {
         case options[0]:
 
           // Shows all Departments w/ their id's and name
-          db.query('SELECT * FROM department', (err, result) => {
+          db.query('SELECT * FROM departments', (err, result) => {
             if (err) {
               console.log(err);
             } else {
@@ -61,7 +61,7 @@ class CLI {
         case options[1]:
 
           // Shows all Roles w/ their id's, titles and salary
-          db.query('SELECT id, title, salary FROM role', (err, result) => {
+          db.query('SELECT departments.id, departments.department, role.title, role.salary FROM departments LEFT JOIN role ON departments.id = role.department_id', (err, result) => {
             if (err) {
               console.log(err);
             } else {


### PR DESCRIPTION
This took a while to figure out but this branch push with all the changes provided can now display display the ID's and department names from the 'departments' table as well as the role titles and their associated salary!

It was a little bit confusing with establishing the query call but I found that you can specify the table and the row of contents you're wanting to merge into a new table with by taking the desired table (departments) and joining it with 'LEFT JOIN' to the secondary table (role) and finally specifying where you would like to join both tables at (in this case I merged it at the end of the department table).

Now I shall do the same with the employee data view selection.