### PR TITLE
Added functionality to 'Add Department'

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,12 +12,21 @@ const options = [
 
 // Presents user with the options array and stores their selection in 'userSelect'
 const question = [
-    {
-        type: 'list',
-        name: 'userSelect',
-        message: 'What would you like to do?',
-        choices: options
-    }
+  {
+    type: 'list',
+    name: 'userSelect',
+    message: 'What would you like to do?',
+    choices: options
+  }
 ];
 
-module.exports = { options, question }
+// When prompt, it will ask the user for a department name to then store in 'userDepartment'
+const department = [
+  {
+    type: 'input',
+    name: 'userDepartment',
+    message: 'What would you like to name this department?',
+  }
+];
+
+module.exports = { options, question, department }

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const mysql = require('mysql2');
 const cTable = require('console.table');
 
 // Allows us to use options and question arrays from 'cli.js'
-const { options, question } = require('./lib/cli.js');
+const { options, question, department } = require('./lib/cli.js');
 
 // Establishes express library call
 const app = express();
@@ -25,6 +25,30 @@ const db = mysql.createConnection(
   console.log(`Connection successful`)
 );
 
+// When called will prompt the user to input a name to add a new department
+function addDepartment() {
+  return inquirer
+
+  // Prompts the user with the department array
+  .prompt(department)
+
+  // Takes the user input and stores it in 'userDepartment'
+  .then(({ userDepartment }) => {
+
+    // Query call to the database that inserts 'userDepartment' as the value
+    db.query(`INSERT INTO departments(department) VALUES('${userDepartment}')`, (err) => {
+      if (err) {
+        console.log(err);
+
+      // If there's no error then it will log to the console that the new department has been added
+      } else {
+        console.log(`${userDepartment} has been added to departments`)
+        cli.run();
+      }
+    });
+  });
+}
+
 class CLI {
   constructor () {}
   run() {
@@ -36,7 +60,6 @@ class CLI {
     // Takes user response stored in 'userSelect'
     .then(({ userSelect }) => {
 
-    let newDepartment;
     let newRole;
     let newEmployee;
 
@@ -44,9 +67,9 @@ class CLI {
     switch (userSelect) {
       
         // Once a match is found it will execute a line of code that the matched statement is associated with
-        case options[0]:
 
-          // Shows all Departments w/ their id's and name
+        // Shows all Departments w/ their id's and name
+        case options[0]:
           db.query(`SELECT * FROM departments`, (err, result) => {
             if (err) {
               console.log(err);
@@ -58,9 +81,8 @@ class CLI {
           });
         break;
               
+        // Shows all Roles w/ their id's, titles, associated departments and salary
         case options[1]:
-
-          // Shows all Roles w/ their id's, titles, associated departments and salary
           db.query(`SELECT role.id, role.title, departments.department, role.salary FROM departments LEFT JOIN role ON departments.id = role.department_id`, (err, result) => {
             if (err) {
               console.log(err);
@@ -72,9 +94,8 @@ class CLI {
           });
         break;
                   
+        // Shows all of the Employees w/ their id's, first and last names, role, department, salary and manager
         case options[2]:
-
-          // Shows all of the Employees w/ their id's, first and last names, role, department, salary and manager
           db.query(`SELECT employee.id, employee.first_name, employee.last_name, role.title, departments.department, role.salary, CONCAT(manager.first_name, ' ', manager.last_name) AS manager FROM departments LEFT JOIN role ON departments.id = role.department_id LEFT JOIN employee ON role.id = employee.role_id LEFT JOIN employee manager ON manager.id = employee.manager_id`, (err, result) => {
             if (err) {
               console.log(err);
@@ -86,8 +107,9 @@ class CLI {
           });
         break;
   
+        // Calls addDepartment function to add the users input of a new department to th
         case options[3]:
-          console.log('Adding a new Department');
+          addDepartment();
         break;
               
         case options[4]:


### PR DESCRIPTION
With this push the user can now add a new department to the database from the 'Add Department' selection in the console!

In 'cli.js' I added an array called 'department' which (when prompted) will ask the user what to name their new department that will be added to the 'departments' table in the database.

When the user selects 'Add Department' it will call the 'addDepartment()' function which will then prompt the 'department' array from 'cli.js' to ask the user to input a department name.

The response from the user is then stored within the 'userSelect' variable to then be used for a query call to which will 'INSERT' the user value to the database (if there is an error then it will log the console with it).

Once the new department is add to the db successfully it will then console log the users response to confirm it's been added and calls 'cli.run()' to bring the user back to the main menu selection.

I also commented all of these changes and took out what wasn't necessary for me to use anymore, next push should be adding functionality to the 'new role'.